### PR TITLE
Updating Github Actions and speed up git clones

### DIFF
--- a/.github/workflows/configuration-artifacts.yml
+++ b/.github/workflows/configuration-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Environment Variables
@@ -22,7 +22,7 @@ jobs:
         echo "CI_SHA=${{ github.sha }}" >> $GITHUB_ENV
       shell: bash
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Environment Variables
@@ -23,7 +23,7 @@ jobs:
         echo "COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}" >> $GITHUB_ENV
       shell: bash
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
@@ -52,4 +52,3 @@ jobs:
 #      run: |
 #        if [ -z "$COVERALLS_REPO_TOKEN" ]; then echo \"COVERALLS_REPO_TOKEN\" secret is undefined!; else poetry run coveralls; fi
 #      shell: bash
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum install --setopt=tsflags=nodocs -y \
 # OpenColorIO Build
 WORKDIR /tmp
 ARG OCIO_INSTALL_DIRECTORY=/usr/local
-RUN git clone https://github.com/AcademySoftwareFoundation/OpenColorIO \
+RUN git clone --depth 1 https://github.com/AcademySoftwareFoundation/OpenColorIO \
     && cd OpenColorIO \
     && mkdir build \
     && mkdir -p ${OCIO_INSTALL_DIRECTORY} \


### PR DESCRIPTION
* CI workflow: Adding `ubuntu-latest` to the OS matrix
* CI workflow: Updating actions to use their newer version. One notable change is the introduction of shallow cloning by default in checkout@v2.
* Dockerfile: shallow clone the "throwaway" OpenColorIO repository inside the container