### PR TITLE
PR: Aliases, NamedTransform, Base Config Inheritance

### DIFF
--- a/docs/opencolorio_config_aces.config.rst
+++ b/docs/opencolorio_config_aces.config.rst
@@ -21,6 +21,7 @@ Config Generation Common Objects
     transform_factory
     group_transform_factory
     colorspace_factory
+    named_transform_factory
     view_transform_factory
     look_factory
     ConfigData

--- a/opencolorio_config_aces/__init__.py
+++ b/opencolorio_config_aces/__init__.py
@@ -26,9 +26,10 @@ from .config import (
     deserialize_config_data, discover_aces_ctl_transforms,
     filter_ctl_transforms, filter_nodes, generate_config, generate_config_aces,
     generate_config_cg, group_transform_factory, look_factory,
-    produce_transform, node_to_ctl_transform, plot_aces_conversion_graph,
-    print_aces_taxonomy, serialize_config_data, transform_factory,
-    unclassify_ctl_transforms, validate_config, view_transform_factory)
+    named_transform_factory, node_to_ctl_transform, plot_aces_conversion_graph,
+    print_aces_taxonomy, produce_transform, serialize_config_data,
+    transform_factory, unclassify_ctl_transforms, validate_config,
+    view_transform_factory)
 from .clf import (classify_clf_transforms, discover_clf_transforms,
                   filter_clf_transforms, generate_clf, print_clf_taxonomy,
                   unclassify_clf_transforms)
@@ -46,10 +47,11 @@ __all__ = [
     'ctl_transform_to_node', 'deserialize_config_data',
     'discover_aces_ctl_transforms', 'filter_ctl_transforms', 'filter_nodes',
     'generate_config', 'generate_config_aces', 'generate_config_cg',
-    'group_transform_factory', 'look_factory', 'produce_transform',
+    'group_transform_factory', 'look_factory', 'named_transform_factory',
     'node_to_ctl_transform', 'plot_aces_conversion_graph',
-    'print_aces_taxonomy', 'serialize_config_data', 'transform_factory',
-    'unclassify_ctl_transforms', 'validate_config', 'view_transform_factory'
+    'print_aces_taxonomy', 'produce_transform', 'serialize_config_data',
+    'transform_factory', 'unclassify_ctl_transforms', 'validate_config',
+    'view_transform_factory'
 ]
 __all__ += [
     'classify_clf_transforms', 'discover_clf_transforms',

--- a/opencolorio_config_aces/config/__init__.py
+++ b/opencolorio_config_aces/config/__init__.py
@@ -3,9 +3,9 @@
 
 from .generation import (
     ConfigData, colorspace_factory, deserialize_config_data, generate_config,
-    group_transform_factory, look_factory, produce_transform,
-    serialize_config_data, transform_factory, validate_config,
-    view_transform_factory)
+    group_transform_factory, look_factory, named_transform_factory,
+    produce_transform, serialize_config_data, transform_factory,
+    validate_config, view_transform_factory)
 from .reference import (
     ColorspaceDescriptionStyle, build_aces_conversion_graph,
     classify_aces_ctl_transforms, conversion_path, ctl_transform_to_node,
@@ -17,8 +17,8 @@ from .cg import generate_config_cg
 __all__ = [
     'ConfigData', 'colorspace_factory', 'deserialize_config_data',
     'generate_config', 'group_transform_factory', 'look_factory',
-    'produce_transform', 'serialize_config_data', 'transform_factory',
-    'validate_config', 'view_transform_factory'
+    'named_transform_factory', 'produce_transform', 'serialize_config_data',
+    'transform_factory', 'validate_config', 'view_transform_factory'
 ]
 __all__ += [
     'ColorspaceDescriptionStyle', 'build_aces_conversion_graph',

--- a/opencolorio_config_aces/config/generation/__init__.py
+++ b/opencolorio_config_aces/config/generation/__init__.py
@@ -3,13 +3,13 @@
 
 from .common import (produce_transform, transform_factory,
                      group_transform_factory, colorspace_factory,
-                     view_transform_factory, look_factory, ConfigData,
-                     deserialize_config_data, serialize_config_data,
-                     validate_config, generate_config)
+                     named_transform_factory, view_transform_factory,
+                     look_factory, ConfigData, deserialize_config_data,
+                     serialize_config_data, validate_config, generate_config)
 
 __all__ = [
     'produce_transform', 'transform_factory', 'group_transform_factory',
-    'colorspace_factory', 'view_transform_factory', 'look_factory',
-    'ConfigData', 'deserialize_config_data', 'serialize_config_data',
-    'validate_config', 'generate_config'
+    'colorspace_factory', 'named_transform_factory', 'view_transform_factory',
+    'look_factory', 'ConfigData', 'deserialize_config_data',
+    'serialize_config_data', 'validate_config', 'generate_config'
 ]

--- a/opencolorio_config_aces/config/generation/common.py
+++ b/opencolorio_config_aces/config/generation/common.py
@@ -751,8 +751,8 @@ if __name__ == '__main__':
                         'only a placeholder!'),
         'to_reference': {
             'name': 'ExponentTransform',
-            'value': [2.2, 2.2, 2.2, 1],
-        },
+            'value': [2.2, 2.2, 2.2, 1]
+        }
     }
     colorspace_3 = {
         'name': 'Colorspace - sRGB',
@@ -761,7 +761,7 @@ if __name__ == '__main__':
             'name': 'ColorSpaceTransform',
             'src': 'CCTF - sRGB',
             'dst': 'Gamut - sRGB',
-        },
+        }
     }
     colorspace_4 = colorspace_factory(**{
         'name': 'Utility - Raw',
@@ -796,7 +796,7 @@ if __name__ == '__main__':
                 _gain_cdl_transform,
             ],
             _gain_cdl_transform,
-        ],
+        ]
     }
     display_1 = {
         'name': 'View - sRGB Monitor - sRGB',
@@ -814,12 +814,12 @@ if __name__ == '__main__':
             {
                 'display': 'sRGB Monitor',
                 'view': 'sRGB - sRGB',
-                'colorspace': display_1['name'],
+                'colorspace': display_1['name']
             },
             {
                 'display': 'sRGB Monitor',
                 'view': 'Raw',
-                'colorspace': colorspace_4.getName(),
+                'colorspace': colorspace_4.getName()
             },
         ],
         active_displays=['sRGB Monitor'],
@@ -861,7 +861,7 @@ if __name__ == '__main__':
                 0.0000000000,
                 0.0000000000,
                 1.0000000000,
-            ],
+            ]
         }
     }
     colorspace_4 = {
@@ -870,7 +870,7 @@ if __name__ == '__main__':
         'to_reference': {
             'name': 'ExponentWithLinearTransform',
             'gamma': [2.4, 2.4, 2.4, 1],
-            'offset': [0.055, 0.055, 0.055, 0],
+            'offset': [0.055, 0.055, 0.055, 0]
         }
     }
     colorspace_5 = {
@@ -884,7 +884,7 @@ if __name__ == '__main__':
         'forward_transform': {
             'name': 'CDLTransform',
             'slope': [0, 0, 0],
-            'offset': [1, 0, 0],
+            'offset': [1, 0, 0]
         }
     }
 
@@ -912,14 +912,14 @@ if __name__ == '__main__':
         'from_reference': {
             'name': 'BuiltinTransform',
             'style': 'ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO_1.0'
-        },
+        }
     }
     view_transform_2 = {
         'name': 'Output - No Tonescale',
         'from_reference': {
             'name': 'BuiltinTransform',
             'style': 'UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD'
-        },
+        }
     }
 
     displays = (display_1, display_2)
@@ -927,7 +927,7 @@ if __name__ == '__main__':
     shared_views = [{
         'display': display['name'],
         'view': view_transform['name'],
-        'view_transform': view_transform['name'],
+        'view_transform': view_transform['name']
     } for display in displays for view_transform in view_transforms]
 
     data = ConfigData(
@@ -935,7 +935,7 @@ if __name__ == '__main__':
         roles={
             'aces_interchange': 'ACES - ACES2065-1',
             'cie_xyz_d65_interchange': 'CIE-XYZ D65',
-            ocio.ROLE_SCENE_LINEAR: colorspace_2['name'],
+            ocio.ROLE_SCENE_LINEAR: colorspace_2['name']
         },
         colorspaces=[
             colorspace_1, colorspace_2, colorspace_3, colorspace_4,

--- a/opencolorio_config_aces/config/generation/common.py
+++ b/opencolorio_config_aces/config/generation/common.py
@@ -139,6 +139,7 @@ def group_transform_factory(transforms):
 def colorspace_factory(name,
                        family=None,
                        encoding=None,
+                       aliases=None,
                        categories=None,
                        description=None,
                        equality_group=None,
@@ -162,6 +163,8 @@ def colorspace_factory(name,
         *OpenColorIO* colorspace family.
     encoding : unicode, optional
         *OpenColorIO* colorspace encoding.
+    aliases : unicode or array_like, optional
+        *OpenColorIO* colorspace aliases.
     categories : unicode or array_like, optional
         *OpenColorIO* colorspace categories.
     description : unicode, optional
@@ -197,9 +200,6 @@ def colorspace_factory(name,
     """
 
     import PyOpenColorIO as ocio
-
-    if categories is None:
-        categories = []
 
     if bit_depth is None:
         bit_depth = ocio.BIT_DEPTH_F32
@@ -242,6 +242,13 @@ def colorspace_factory(name,
 
     if encoding is not None:
         colorspace.setEncoding(encoding)
+
+    if aliases is not None:
+        if isinstance(aliases, str):
+            aliases = [aliases]
+
+        for alias in aliases:
+            colorspace.addAlias(alias)
 
     if categories is not None:
         if isinstance(categories, str):
@@ -829,7 +836,11 @@ if __name__ == '__main__':
     generate_config(data, os.path.join(build_directory, 'config-v1.ocio'))
 
     # "OpenColorIO 2" configuration.
-    colorspace_1 = {'name': 'ACES - ACES2065-1', 'family': 'ACES'}
+    colorspace_1 = {
+        'name': 'ACES - ACES2065-1',
+        'family': 'ACES',
+        'aliases': 'lin_ap0'
+    }
     colorspace_2 = {
         'name': 'ACES - ACEScg',
         'family': 'ACES',
@@ -837,6 +848,7 @@ if __name__ == '__main__':
             'name': 'BuiltinTransform',
             'style': 'ACEScg_to_ACES2065-1',
         },
+        'aliases': ['lin_ap1']
     }
     colorspace_3 = {
         'name': 'Gamut - sRGB',

--- a/opencolorio_config_aces/config/generation/common.py
+++ b/opencolorio_config_aces/config/generation/common.py
@@ -183,8 +183,7 @@ def colorspace_factory(name,
     is_data : bool, optional
         Whether the colorspace represents data.
     base_colorspace : dict or ColorSpace, optional
-        *OpenColorIO* base colorspace inherited for bit depth, allocation,
-        allocation variables, and to/from reference transforms.
+        *OpenColorIO* base colorspace inherited for initial attribute values.
 
     Other Parameters
     ----------------
@@ -287,13 +286,14 @@ def view_transform_factory(name,
     description : unicode, optional
         *OpenColorIO* view transform description.
     to_reference : dict or object, optional
-        *To Reference* *OpenColorIO* view transform transform.
+        *To Reference* *OpenColorIO* view transform.
     from_reference : dict or object, optional
-        *From Reference* *OpenColorIO* view transform transform.
+        *From Reference* *OpenColorIO* view transform.
     reference_space : unicode or ReferenceSpaceType, optional
         *OpenColorIO* view transform reference space.
     base_view_transform : dict or ViewTransform, optional
-        Inherited *OpenColorIO* base view transform.
+        *OpenColorIO* base view transform inherited for initial attribute
+        values.
 
     Other Parameters
     ----------------
@@ -373,7 +373,7 @@ def look_factory(name,
     inverse_transform : dict or object, optional
         *From Reference* *OpenColorIO* look transform.
     base_look : dict or ViewTransform, optional
-        Inherited *OpenColorIO* base look.
+        *OpenColorIO* base look inherited for initial attribute values.
 
     Other Parameters
     ----------------
@@ -432,13 +432,18 @@ class ConfigData:
         Config roles, a dict of role and colorspace name.
     colorspaces : array_like
         Config colorspaces, an iterable of
-        :attr:`PyOpenColorIO.ColorSpace` class instances.
-    looks : array_like, optional
-        Config looks, an iterable of :attr:`PyOpenColorIO.Look` class
-        instances.
+        :attr:`PyOpenColorIO.ColorSpace` class instances or mappings to create
+        them with :func:`opencolorio_config_aces.colorspace_factory`
+        definition.
     view_transforms : array_like, optional
         Config view transforms, an iterable of
-        :attr:`PyOpenColorIO.ViewTransform` class instances.
+        :attr:`PyOpenColorIO.ViewTransform` class instances or mappings to
+        create them with :func:`opencolorio_config_aces.view_transform_factory`
+        definition.
+    looks : array_like, optional
+        Config looks, an iterable of :attr:`PyOpenColorIO.Look` class
+        instances or mappings to create them with
+        :func:`opencolorio_config_aces.look_factory` definition.
     shared_views : array_like, optional
         Config shared views, an iterable of dicts of view, view transform,
         colorspace and rule names, iterable of looks and description.
@@ -466,8 +471,8 @@ class ConfigData:
     search_path
     roles
     colorspaces
-    looks
     view_transforms
+    looks
     shared_views
     views
     active_displays
@@ -485,8 +490,8 @@ class ConfigData:
     search_path: Union[list] = field(default_factory=list)
     roles: Union[dict, OrderedDict] = field(default_factory=dict)
     colorspaces: Union[list] = field(default_factory=list)
-    looks: Union[list] = field(default_factory=list)
     view_transforms: Union[list] = field(default_factory=list)
+    looks: Union[list] = field(default_factory=list)
     shared_views: Union[list] = field(default_factory=list)
     views: Union[list] = field(default_factory=list)
     active_displays: Union[list] = field(default_factory=list)


### PR DESCRIPTION
This PR implements support for:

- Aliases for the `opencolorio_config_aces.colorspace_factory` definition.
- `NamedTransform` creation via the `opencolorio_config_aces.named_transform_factory` definition.
- Base config inheritance in the `opencolorio_config_aces.generate_config` definition so that the config can be generated from an existing config, e.g. ACES 1.2 config.
- Small polishing updates.

The important milestone is that it is the first time I'm using the repository and the exposed API to generate custom configs at work. It is quite neat and I managed to remove a lot of our custom code!

I will see if I can put together a small example on how to programmatically modify the ACES 1.2 config.