### PR TITLE
PR: Minor Improvements

### DIFF
--- a/docs/opencolorio_config_aces.utilities.rst
+++ b/docs/opencolorio_config_aces.utilities.rst
@@ -33,3 +33,4 @@ Common
     is_string
     is_iterable
     git_describe
+    matrix_3x3_to_4x4

--- a/docs/opencolorio_config_aces.utilities.rst
+++ b/docs/opencolorio_config_aces.utilities.rst
@@ -34,3 +34,4 @@ Common
     is_iterable
     git_describe
     matrix_3x3_to_4x4
+    multi_replace

--- a/opencolorio_config_aces/clf/__init__.py
+++ b/opencolorio_config_aces/clf/__init__.py
@@ -5,10 +5,10 @@ from .discover import (discover_clf_transforms, classify_clf_transforms,
                        unclassify_clf_transforms, filter_clf_transforms,
                        print_clf_taxonomy)
 
-from .transforms import matrix_3x3_to_4x4, generate_clf
+from .transforms import generate_clf
 
 __all__ = [
     'discover_clf_transforms', 'classify_clf_transforms',
     'unclassify_clf_transforms', 'filter_clf_transforms', 'print_clf_taxonomy'
 ]
-__all__ += ['matrix_3x3_to_4x4', 'generate_clf']
+__all__ += ['generate_clf']

--- a/opencolorio_config_aces/clf/discover/classify.py
+++ b/opencolorio_config_aces/clf/discover/classify.py
@@ -33,32 +33,32 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'CLF_URN', 'CLF_URN_SEPARATOR', 'CLF_ID_SEPARATOR', 'CLF_NAMESPACE',
-    'CLF_TYPES', 'CLF_TRANSFORMS_ROOT', 'CLF_TRANSFORM_FAMILIES',
-    'DEFAULT_CLF_TRANSFORM_GENUS', 'DEFAULT_CLF_TRANSFORM_FILTERERS',
-    'DESCRIPTION_SUBSTITUTION_PATTERNS', 'clf_transform_relative_path',
-    'CLFTransformID', 'CLFTransform', 'CLFTransformPair',
-    'find_clf_transform_pairs', 'discover_clf_transforms',
+    'URN_CLF', 'SEPARATOR_URN_CLF', 'SEPARATOR_ID_CLF', 'NAMESPACE_CLF',
+    'TRANSFORM_TYPES_CLF', 'TRANSFORM_FAMILIES_CLF',
+    'TRANSFORM_GENUS_DEFAULT_CLF', 'TRANSFORM_FILTERERS_DEFAULT_CLF',
+    'PATTERNS_DESCRIPTION_CLF', 'ROOT_TRANSFORMS_CLF',
+    'clf_transform_relative_path', 'CLFTransformID', 'CLFTransform',
+    'CLFTransformPair', 'find_clf_transform_pairs', 'discover_clf_transforms',
     'classify_clf_transforms', 'unclassify_clf_transforms',
     'filter_clf_transforms', 'print_clf_taxonomy'
 ]
 
-CLF_URN = 'urn:aswf:ocio:transformId:v1.0'
+URN_CLF = 'urn:aswf:ocio:transformId:v1.0'
 """
 *CLF* Uniform Resource Name (*URN*).
 
-CLF_URN : unicode
+URN_CLF : unicode
 """
 
-CLF_URN_SEPARATOR = ':'
+SEPARATOR_URN_CLF = ':'
 """
 *CLFtransformID* separator used to separate the *URN* and *ID* part of the
 *CLFtransformID*.
 
-CLF_URN_SEPARATOR : unicode
+SEPARATOR_URN_CLF : unicode
 """
 
-CLF_ID_SEPARATOR = '.'
+SEPARATOR_ID_CLF = '.'
 """
 *CLFtransformID* separator used to tokenize the *ID* part of the
 *CLFtransformID*.
@@ -66,27 +66,56 @@ CLF_ID_SEPARATOR = '.'
 urn:aswf:ocio:transformId:v1.0:ACES.OCIO.AP0_to_AP1-Gamma2pnt2.c1.v1
 |-------------URN------------|:|-----------------ID----------------|
 
-CLF_ID_SEPARATOR : unicode
+SEPARATOR_ID_CLF : unicode
 """
 
-CLF_NAMESPACE = 'OCIO'
+NAMESPACE_CLF = 'OCIO'
 """
 *ACES* namespace for the *OCIO* *CLF* transforms.
 
-CLF_NAMESPACE : unicode
+NAMESPACE_CLF : unicode
 """
 
-CLF_TYPES = [
+TRANSFORM_TYPES_CLF = [
     'ACES',
     'Common',
 ]
 """
 *CLF* transform types.
 
-CLF_TYPES : list
+TRANSFORM_TYPES_CLF : list
 """
 
-CLF_TRANSFORMS_ROOT = os.path.normpath(
+TRANSFORM_FAMILIES_CLF = {'aces': 'aces'}
+"""
+*CLF* transform families mapping the *CLF* transform directories to family
+names.
+
+TRANSFORM_FAMILIES_CLF : dict
+"""
+
+TRANSFORM_GENUS_DEFAULT_CLF = 'undefined'
+"""
+*CLF* transform default genus, i.e. *undefined*.
+
+TRANSFORM_GENUS_DEFAULT_CLF : unicode
+"""
+
+TRANSFORM_FILTERERS_DEFAULT_CLF = []
+"""
+Default list of *CLF* transform filterers.
+
+TRANSFORM_FILTERERS_DEFAULT_CLF : list
+"""
+
+PATTERNS_DESCRIPTION_CLF = {}
+"""
+*CLF* transform description substitution patterns.
+
+PATTERNS_DESCRIPTION_CLF : dict
+"""
+
+ROOT_TRANSFORMS_CLF = os.path.normpath(
     os.environ.get(
         'OPENCOLORIO_CONFIG_ACES__CLF_TRANSFORMS_ROOT',
         os.path.join(
@@ -97,40 +126,11 @@ sub-module repository. It can be defined by setting the
 `OPENCOLORIO_CONFIG_ACES__CLF_TRANSFORMS_ROOT` environment variable with
 the local 'transforms/clf' directory.
 
-CLF_TRANSFORMS_ROOT : unicode
-"""
-
-CLF_TRANSFORM_FAMILIES = {'aces': 'aces'}
-"""
-*CLF* transform families mapping the *CLF* transform directories to family
-names.
-
-CLF_TRANSFORM_FAMILIES : dict
-"""
-
-DEFAULT_CLF_TRANSFORM_GENUS = 'undefined'
-"""
-*CLF* transform default genus, i.e. *undefined*.
-
-DEFAULT_CLF_TRANSFORM_GENUS : unicode
-"""
-
-DESCRIPTION_SUBSTITUTION_PATTERNS = {}
-"""
-*CLF* transform description substitution patterns.
-
-DESCRIPTION_SUBSTITUTION_PATTERNS : dict
-"""
-
-DEFAULT_CLF_TRANSFORM_FILTERERS = []
-"""
-Default list of *CLF* transform filterers.
-
-DEFAULT_CLF_TRANSFORM_FILTERERS : list
+ROOT_TRANSFORMS_CLF : unicode
 """
 
 
-def clf_transform_relative_path(path, root_directory=CLF_TRANSFORMS_ROOT):
+def clf_transform_relative_path(path, root_directory=ROOT_TRANSFORMS_CLF):
     """
     Helper definition returning the relative path from given *CLF* transform to
     *CLF* transforms root directory.
@@ -457,11 +457,11 @@ class CLFTransformID:
 
         clf_transform_id = self._clf_transform_id
 
-        self._urn, components = clf_transform_id.rsplit(CLF_URN_SEPARATOR, 1)
-        components = components.split(CLF_ID_SEPARATOR)
+        self._urn, components = clf_transform_id.rsplit(SEPARATOR_URN_CLF, 1)
+        components = components.split(SEPARATOR_ID_CLF)
         self._type, components = components[0], components[1:]
 
-        assert self._urn == CLF_URN, (
+        assert self._urn == URN_CLF, (
             f'{self._clf_transform_id} URN {self._urn} is invalid!')
 
         assert len(components) in (4, 5), (
@@ -475,7 +475,7 @@ class CLFTransformID:
              self._minor_version_number,
              self._patch_version_number) = components
 
-        assert self._type in CLF_TYPES, (
+        assert self._type in TRANSFORM_TYPES_CLF, (
             f'{self._clf_transform_id} type {self._type} is invalid!')
 
         if self._name is not None:
@@ -647,7 +647,7 @@ class CLFTransform:
         Getter and setter property for the *CLF* transform family, e.g.
         *aces*, a value in
         :attr:`opencolorio_config_aces.clf.reference.\
-CLF_TRANSFORM_FAMILIES` attribute dictionary.
+TRANSFORM_FAMILIES_CLF` attribute dictionary.
 
         Parameters
         ----------
@@ -986,7 +986,7 @@ def find_clf_transform_pairs(clf_transforms):
     return clf_transform_pairs
 
 
-def discover_clf_transforms(root_directory=CLF_TRANSFORMS_ROOT):
+def discover_clf_transforms(root_directory=ROOT_TRANSFORMS_CLF):
     """
     Discovers the *CLF* transform paths in given root directory: The given
     directory is traversed and the `*.clf` files are collected.
@@ -1090,11 +1090,11 @@ CLFTransform('aces...ACES.OCIO.AP0_to_P3-D65.clf'))]
     for directory, clf_transforms in unclassified_clf_transforms.items():
         sub_directory = directory.replace(f'{root_directory}{os.sep}', '')
         family, *genus = [
-            CLF_TRANSFORM_FAMILIES.get(part, part)
+            TRANSFORM_FAMILIES_CLF.get(part, part)
             for part in sub_directory.split(os.sep)
         ]
 
-        genus = DEFAULT_CLF_TRANSFORM_GENUS if not genus else '/'.join(genus)
+        genus = TRANSFORM_GENUS_DEFAULT_CLF if not genus else '/'.join(genus)
 
         for basename, pairs in find_clf_transform_pairs(
                 clf_transforms).items():
@@ -1208,7 +1208,7 @@ def filter_clf_transforms(clf_transforms, filterers=None):
     """
 
     if filterers is None:
-        filterers = DEFAULT_CLF_TRANSFORM_FILTERERS
+        filterers = TRANSFORM_FILTERERS_DEFAULT_CLF
 
     if isinstance(clf_transforms, Mapping):
         clf_transforms = unclassify_clf_transforms(clf_transforms)
@@ -1231,7 +1231,7 @@ def print_clf_taxonomy():
 
     -   The *CLF* transforms are discovered by traversing the directory defined
     by the :attr:`opencolorio_config_aces.clf.\
-reference.CLF_TRANSFORMS_ROOT` attribute using the
+reference.ROOT_TRANSFORMS_CLF` attribute using the
         :func:`opencolorio_config_aces.discover_clf_transforms` definition.
     -   The *CLF* transforms are classified by *family* e.g. *aces*, and
         *genus* e.g. *undefined* using the

--- a/opencolorio_config_aces/clf/transforms/__init__.py
+++ b/opencolorio_config_aces/clf/transforms/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-from .common import matrix_3x3_to_4x4, generate_clf
+from .common import generate_clf
 
-__all__ = ['matrix_3x3_to_4x4', 'generate_clf']
+__all__ = ['generate_clf']

--- a/opencolorio_config_aces/clf/transforms/aces.py
+++ b/opencolorio_config_aces/clf/transforms/aces.py
@@ -159,7 +159,7 @@ if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
 
     build_directory = os.path.join(
-        opencolorio_config_aces.clf.discover.classify.CLF_TRANSFORMS_ROOT,
+        opencolorio_config_aces.clf.discover.classify.ROOT_TRANSFORMS_CLF,
         'aces')
 
     if os.path.exists(build_directory):

--- a/opencolorio_config_aces/clf/transforms/aces.py
+++ b/opencolorio_config_aces/clf/transforms/aces.py
@@ -11,9 +11,9 @@ Defines various objects related to the generation of the *ACES* specific
 import logging
 from pathlib import Path
 
-from opencolorio_config_aces.clf import generate_clf, matrix_3x3_to_4x4
+from opencolorio_config_aces.clf import generate_clf
 from opencolorio_config_aces.config.generation import transform_factory
-from opencolorio_config_aces.utilities import required
+from opencolorio_config_aces.utilities import matrix_3x3_to_4x4, required
 
 __author__ = 'OpenColorIO Contributors'
 __copyright__ = 'Copyright Contributors to the OpenColorIO Project.'

--- a/opencolorio_config_aces/clf/transforms/common.py
+++ b/opencolorio_config_aces/clf/transforms/common.py
@@ -25,20 +25,7 @@ __maintainer__ = 'OpenColorIO Contributors'
 __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
-__all__ = ['matrix_3x3_to_4x4', 'generate_clf', 'generate_clf_common']
-
-
-def matrix_3x3_to_4x4(M):
-    """
-    Converts given 3x3 matrix :math:`M` to a raveled 4x4 matrix.
-    """
-
-    import numpy as np
-
-    M_I = np.identity(4)
-    M_I[:3, :3] = M
-
-    return np.ravel(M_I).tolist()
+__all__ = ['generate_clf', 'generate_clf_common']
 
 
 @required('OpenColorIO')

--- a/opencolorio_config_aces/clf/transforms/common.py
+++ b/opencolorio_config_aces/clf/transforms/common.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         description='Conversion from sRGB gamut to ACES2065-1 gamut.')
 
     build_directory = os.path.join(
-        opencolorio_config_aces.clf.discover.classify.CLF_TRANSFORMS_ROOT,
+        opencolorio_config_aces.clf.discover.classify.ROOT_TRANSFORMS_CLF,
         'common')
 
     if os.path.exists(build_directory):

--- a/opencolorio_config_aces/config/cg/generate/config.py
+++ b/opencolorio_config_aces/config/cg/generate/config.py
@@ -34,11 +34,11 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'ACES_CONFIG_CG_MAPPING_FILE_PATH', 'clf_transform_to_description',
+    'PATH_TRANSFORMS_MAPPING_FILE_CG', 'clf_transform_to_description',
     'clf_transform_to_colorspace', 'generate_config_cg'
 ]
 
-ACES_CONFIG_CG_MAPPING_FILE_PATH = (
+PATH_TRANSFORMS_MAPPING_FILE_CG = (
     Path(__file__).parents[0] / 'resources' /
     'OpenColorIO-Config-ACES _CG_ Transforms - CG Config - Mapping.csv')
 """
@@ -146,7 +146,7 @@ def generate_config_cg(
         config_name=None,
         validate=True,
         describe=ColorspaceDescriptionStyle.SHORT_UNION,
-        config_mapping_file_path=ACES_CONFIG_CG_MAPPING_FILE_PATH,
+        config_mapping_file_path=PATH_TRANSFORMS_MAPPING_FILE_CG,
         additional_data=False):
     """
     Generates the *ACES* Computer Graphics (CG) *OpenColorIO* config.

--- a/opencolorio_config_aces/config/generation/common.py
+++ b/opencolorio_config_aces/config/generation/common.py
@@ -37,18 +37,18 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'LOG_ALLOCATION_VARS', 'produce_transform', 'transform_factory',
+    'ALLOCATION_VARS_LOG', 'produce_transform', 'transform_factory',
     'group_transform_factory', 'colorspace_factory', 'named_transform_factory',
     'view_transform_factory', 'look_factory', 'ConfigData',
     'deserialize_config_data', 'serialize_config_data', 'validate_config',
     'generate_config'
 ]
 
-LOG_ALLOCATION_VARS = (-8, 5, 2**-8)
+ALLOCATION_VARS_LOG = (-8, 5, 2**-8)
 """
 Allocation variables for logarithmic data representation.
 
-LOG_ALLOCATION_VARS : tuple
+ALLOCATION_VARS_LOG : tuple
 """
 
 

--- a/opencolorio_config_aces/config/reference/discover/classify.py
+++ b/opencolorio_config_aces/config/reference/discover/classify.py
@@ -31,32 +31,32 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'ACES_URN', 'ACES_URN_SEPARATOR', 'ACES_ID_SEPARATOR', 'ACES_NAMESPACE',
-    'ACES_TYPES', 'ACES_CTL_TRANSFORMS_ROOT', 'ACES_CTL_TRANSFORM_FAMILIES',
-    'DEFAULT_ACES_CTL_TRANSFORM_GENUS', 'DEFAULT_ACES_CTL_TRANSFORM_FILTERERS',
-    'DESCRIPTION_SUBSTITUTION_PATTERNS', 'patch_invalid_aces_transform_id',
-    'ctl_transform_relative_path', 'ACESTransformID', 'CTLTransform',
-    'CTLTransformPair', 'find_ctl_transform_pairs',
+    'URN_CTL', 'SEPARATOR_URN_CTL', 'SEPARATOR_ID_CTL', 'NAMESPACE_CTL',
+    'TRANSFORM_TYPES_CTL', 'TRANSFORM_FAMILIES_CTL',
+    'TRANSFORM_GENUS_DEFAULT_CTL', 'TRANSFORM_FILTERERS_DEFAULT_CTL',
+    'PATTERNS_DESCRIPTION_CTL', 'patch_invalid_aces_transform_id',
+    'ROOT_TRANSFORMS_CTL', 'ctl_transform_relative_path', 'ACESTransformID',
+    'CTLTransform', 'CTLTransformPair', 'find_ctl_transform_pairs',
     'discover_aces_ctl_transforms', 'classify_aces_ctl_transforms',
     'unclassify_ctl_transforms', 'filter_ctl_transforms', 'print_aces_taxonomy'
 ]
 
-ACES_URN = 'urn:ampas:aces:transformId:v1.5'
+URN_CTL = 'urn:ampas:aces:transformId:v1.5'
 """
 *ACES* Uniform Resource Name (*URN*).
 
-ACES_URN : unicode
+URN_CTL : unicode
 """
 
-ACES_URN_SEPARATOR = ':'
+SEPARATOR_URN_CTL = ':'
 """
 *ACEStransformID* separator used to separate the *URN* and *ID* part of the
 *ACEStransformID*.
 
-ACES_URN_SEPARATOR : unicode
+SEPARATOR_URN_CTL : unicode
 """
 
-ACES_ID_SEPARATOR = '.'
+SEPARATOR_ID_CTL = '.'
 """
 *ACEStransformID* separator used to tokenize the *ID* part of the
 *ACEStransformID*.
@@ -64,17 +64,17 @@ ACES_ID_SEPARATOR = '.'
 urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3
 |-------------URN-------------|:|----------ID---------|
 
-ACES_ID_SEPARATOR : unicode
+SEPARATOR_ID_CTL : unicode
 """
 
-ACES_NAMESPACE = 'Academy'
+NAMESPACE_CTL = 'Academy'
 """
 *ACES* namespace for *A.M.P.A.S* official *CTL* transforms.
 
-ACES_NAMESPACE : unicode
+NAMESPACE_CTL : unicode
 """
 
-ACES_TYPES = [
+TRANSFORM_TYPES_CTL = [
     'IDT',
     'LMT',
     'ODT',
@@ -90,25 +90,10 @@ ACES_TYPES = [
 """
 *ACES* *CTL* transform types.
 
-ACES_TYPES : list
+TRANSFORM_TYPES_CTL : list
 """
 
-ACES_CTL_TRANSFORMS_ROOT = os.path.normpath(
-    os.environ.get(
-        'OPENCOLORIO_CONFIG_ACES__ACES_CTL_TRANSFORMS_ROOT',
-        os.path.join(
-            os.path.dirname(__file__), '../', 'aces-dev', 'transforms',
-            'ctl')))
-"""
-*aces-dev* *CTL* transforms root directory, default to the version controlled
-sub-module repository. It can be defined by setting the
-`OPENCOLORIO_CONFIG_ACES__ACES_CTL_TRANSFORMS_ROOT` environment variable with
-the local 'aces-dev/transforms/ctl' directory.
-
-ACES_CTL_TRANSFORMS_ROOT : unicode
-"""
-
-ACES_CTL_TRANSFORM_FAMILIES = {
+TRANSFORM_FAMILIES_CTL = {
     'csc': 'csc',
     'idt': 'input_transform',
     'lib': 'lib',
@@ -122,24 +107,14 @@ ACES_CTL_TRANSFORM_FAMILIES = {
 *ACES* *CTL* transform families mapping the *CTL* transform directories to
 family names.
 
-ACES_CTL_TRANSFORM_FAMILIES : dict
+TRANSFORM_FAMILIES_CTL : dict
 """
 
-DEFAULT_ACES_CTL_TRANSFORM_GENUS = 'undefined'
+TRANSFORM_GENUS_DEFAULT_CTL = 'undefined'
 """
 *ACES* *CTL* transform default genus, i.e. *undefined*.
 
-DEFAULT_ACES_CTL_TRANSFORM_GENUS : unicode
-"""
-
-DESCRIPTION_SUBSTITUTION_PATTERNS = {
-    '============ CONSTANTS ============ //': '',
-    'Written by .*_IDT_maker\\.py v.* on .*': ''
-}
-"""
-*ACES* *CTL* transform description substitution patterns.
-
-DESCRIPTION_SUBSTITUTION_PATTERNS : dict
+TRANSFORM_GENUS_DEFAULT_CTL : unicode
 """
 
 
@@ -173,13 +148,23 @@ def _exclusion_filterer_ARRIIDT(ctl_transform):
     return False
 
 
-DEFAULT_ACES_CTL_TRANSFORM_FILTERERS = [
+TRANSFORM_FILTERERS_DEFAULT_CTL = [
     _exclusion_filterer_ARRIIDT,
 ]
 """
 Default list of *ACES* *CTL* transform filterers.
 
-DEFAULT_ACES_CTL_TRANSFORM_FILTERERS : list
+TRANSFORM_FILTERERS_DEFAULT_CTL : list
+"""
+
+PATTERNS_DESCRIPTION_CTL = {
+    '============ CONSTANTS ============ //': '',
+    'Written by .*_IDT_maker\\.py v.* on .*': ''
+}
+"""
+*ACES* *CTL* transform description substitution patterns.
+
+PATTERNS_DESCRIPTION_CTL : dict
 """
 
 
@@ -210,10 +195,10 @@ commit/4b88ef35afc41e58ea52d9acde68af24e75b58c5
     # commit/4b88ef35afc41e58ea52d9acde68af24e75b58c5
     if False:
         invalid_id = aces_transform_id
-        if not aces_transform_id.startswith(ACES_URN):
+        if not aces_transform_id.startswith(URN_CTL):
             logging.warning(f'{invalid_id} is missing "ACES" URN!')
 
-            aces_transform_id = f'{ACES_URN}:{aces_transform_id}'
+            aces_transform_id = f'{URN_CTL}:{aces_transform_id}'
 
         if 'Academy.P3D65_108nits_7.2nits_ST2084' in aces_transform_id:
             logging.warning(
@@ -247,7 +232,23 @@ commit/4b88ef35afc41e58ea52d9acde68af24e75b58c5
     return aces_transform_id
 
 
-def ctl_transform_relative_path(path, root_directory=ACES_CTL_TRANSFORMS_ROOT):
+ROOT_TRANSFORMS_CTL = os.path.normpath(
+    os.environ.get(
+        'OPENCOLORIO_CONFIG_CTL__CTL_TRANSFORMS_ROOT',
+        os.path.join(
+            os.path.dirname(__file__), '../', 'aces-dev', 'transforms',
+            'ctl')))
+"""
+*aces-dev* *CTL* transforms root directory, default to the version controlled
+sub-module repository. It can be defined by setting the
+`OPENCOLORIO_CONFIG_CTL__CTL_TRANSFORMS_ROOT` environment variable with
+the local 'aces-dev/transforms/ctl' directory.
+
+ROOT_TRANSFORMS_CTL : unicode
+"""
+
+
+def ctl_transform_relative_path(path, root_directory=ROOT_TRANSFORMS_CTL):
     """
     Helper definition returning the relative path from given *ACES* *CTL*
     transform to *aces-dev* *CTL* transforms root directory.
@@ -577,11 +578,11 @@ class ACESTransformID:
         aces_transform_id = patch_invalid_aces_transform_id(
             self._aces_transform_id)
 
-        self._urn, components = aces_transform_id.rsplit(ACES_URN_SEPARATOR, 1)
-        components = components.split(ACES_ID_SEPARATOR)
+        self._urn, components = aces_transform_id.rsplit(SEPARATOR_URN_CTL, 1)
+        components = components.split(SEPARATOR_ID_CTL)
         self._type, components = components[0], components[1:]
 
-        assert self._urn == ACES_URN, (
+        assert self._urn == URN_CTL, (
             f'{self._aces_transform_id} URN {self._urn} is invalid!')
 
         assert len(components) in (3, 4, 5), (
@@ -603,7 +604,7 @@ class ACESTransformID:
              self._minor_version_number,
              self._patch_version_number) = components
 
-        assert self._type in ACES_TYPES, (
+        assert self._type in TRANSFORM_TYPES_CTL, (
             f'{self._aces_transform_id} type {self._type} is invalid!')
 
         if self._name is not None:
@@ -803,7 +804,7 @@ class CTLTransform:
         Getter and setter property for the *ACES* *CTL* transform family, e.g.
         *output_transform*, a value in
         :attr:`opencolorio_config_aces.config.reference.\
-ACES_CTL_TRANSFORM_FAMILIES` attribute dictionary.
+TRANSFORM_FAMILIES_CTL` attribute dictionary.
 
         Parameters
         ----------
@@ -960,7 +961,7 @@ CTLTransform` class are tried on the underlying
                 line = line[2:].strip()
 
                 for pattern, substitution in (
-                        DESCRIPTION_SUBSTITUTION_PATTERNS.items()):
+                        PATTERNS_DESCRIPTION_CTL.items()):
                     line = re.sub(pattern, substitution, line)
 
                 self._description += line
@@ -1166,7 +1167,7 @@ def find_ctl_transform_pairs(ctl_transforms):
     return ctl_transform_pairs
 
 
-def discover_aces_ctl_transforms(root_directory=ACES_CTL_TRANSFORMS_ROOT):
+def discover_aces_ctl_transforms(root_directory=ROOT_TRANSFORMS_CTL):
     """
     Discovers the *ACES* *CTL* transform paths in given root directory: The
     given directory is traversed and the `*.ctl` files are collected.
@@ -1272,12 +1273,11 @@ CTLTransform('csc...ACEScc...ACEScsc.Academy.ACEScc_to_ACES.ctl')'))]
     for directory, ctl_transforms in unclassified_ctl_transforms.items():
         sub_directory = directory.replace(f'{root_directory}{os.sep}', '')
         family, *genus = [
-            ACES_CTL_TRANSFORM_FAMILIES.get(part, part)
+            TRANSFORM_FAMILIES_CTL.get(part, part)
             for part in sub_directory.split(os.sep)
         ]
 
-        genus = DEFAULT_ACES_CTL_TRANSFORM_GENUS if not genus else '/'.join(
-            genus)
+        genus = TRANSFORM_GENUS_DEFAULT_CTL if not genus else '/'.join(genus)
 
         for basename, pairs in find_ctl_transform_pairs(
                 ctl_transforms).items():
@@ -1390,7 +1390,7 @@ def filter_ctl_transforms(ctl_transforms, filterers=None):
     """
 
     if filterers is None:
-        filterers = DEFAULT_ACES_CTL_TRANSFORM_FILTERERS
+        filterers = TRANSFORM_FILTERERS_DEFAULT_CTL
 
     if isinstance(ctl_transforms, Mapping):
         ctl_transforms = unclassify_ctl_transforms(ctl_transforms)
@@ -1413,7 +1413,7 @@ def print_aces_taxonomy():
 
     -   The *aces-dev* *CTL* transforms are discovered by traversing the
         directory defined by the :attr:`opencolorio_config_aces.config.\
-reference.ACES_CTL_TRANSFORMS_ROOT` attribute using the
+reference.ROOT_TRANSFORMS_CTL` attribute using the
         :func:`opencolorio_config_aces.discover_aces_ctl_transforms`
         definition.
     -   The *CTL* transforms are classified by *family* e.g.

--- a/opencolorio_config_aces/config/reference/discover/graph.py
+++ b/opencolorio_config_aces/config/reference/discover/graph.py
@@ -32,16 +32,16 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'NODE_NAME_SEPARATOR', 'build_aces_conversion_graph',
+    'SEPARATOR_NODE_NAME_CTL', 'build_aces_conversion_graph',
     'node_to_ctl_transform', 'ctl_transform_to_node', 'filter_nodes',
     'conversion_path', 'plot_aces_conversion_graph'
 ]
 
-NODE_NAME_SEPARATOR = '/'
+SEPARATOR_NODE_NAME_CTL = '/'
 """
 *aces-dev* conversion graph node name separator.
 
-NODE_NAME_SEPARATOR : unicode
+SEPARATOR_NODE_NAME_CTL : unicode
 """
 
 
@@ -111,9 +111,9 @@ def build_aces_conversion_graph(ctl_transforms):
                 continue
 
         source = (source if source in ('ACES2065-1', 'OCES') else
-                  f'{type_}{NODE_NAME_SEPARATOR}{source}')
+                  f'{type_}{SEPARATOR_NODE_NAME_CTL}{source}')
         target = (target if target in ('ACES2065-1', 'OCES') else
-                  f'{type_}{NODE_NAME_SEPARATOR}{target}')
+                  f'{type_}{SEPARATOR_NODE_NAME_CTL}{target}')
 
         # Serializing the data for "Graphviz AGraph".
         serialized = codecs.encode(pickle.dumps(ctl_transform, 4),

--- a/opencolorio_config_aces/config/reference/generate/analytical.py
+++ b/opencolorio_config_aces/config/reference/generate/analytical.py
@@ -14,17 +14,17 @@ import logging
 from opencolorio_config_aces.config.generation import (
     ConfigData, colorspace_factory, generate_config)
 from opencolorio_config_aces.config.reference.discover.graph import (
-    NODE_NAME_SEPARATOR)
+    SEPARATOR_NODE_NAME_CTL)
 from opencolorio_config_aces.config.reference import (
     ColorspaceDescriptionStyle, build_aces_conversion_graph,
     classify_aces_ctl_transforms, conversion_path,
     discover_aces_ctl_transforms, filter_nodes, filter_ctl_transforms,
     node_to_ctl_transform)
 from opencolorio_config_aces.config.reference.generate.config import (
-    ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR,
-    ACES_CONFIG_COLORSPACE_NAME_SEPARATOR,
-    ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE, ACES_CONFIG_REFERENCE_COLORSPACE,
-    beautify_display_name, beautify_name, ctl_transform_to_colorspace)
+    SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE,
+    SEPARATOR_COLORSPACE_NAME_REFERENCE, COLORSPACE_OUTPUT_ENCODING_REFERENCE,
+    COLORSPACE_SCENE_ENCODING_REFERENCE, beautify_display_name, beautify_name,
+    ctl_transform_to_colorspace)
 from opencolorio_config_aces.utilities import required
 
 __author__ = 'OpenColorIO Contributors'
@@ -35,21 +35,21 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'VIEW_NAME_SUBSTITUTION_PATTERNS', 'beautify_view_name',
+    'PATTERNS_VIEW_NAME_REFERENCE', 'beautify_view_name',
     'create_builtin_transform', 'node_to_builtin_transform',
     'node_to_colorspace', 'generate_config_aces'
 ]
 
-VIEW_NAME_SUBSTITUTION_PATTERNS = {
+PATTERNS_VIEW_NAME_REFERENCE = {
     '\\(100 nits\\) dim': '',
     '\\(100 nits\\)': '',
     '\\(48 nits\\)': '',
-    f'Output{ACES_CONFIG_COLORSPACE_NAME_SEPARATOR}': '',
+    f'Output{SEPARATOR_COLORSPACE_NAME_REFERENCE}': '',
 }
 """
 *OpenColorIO* view name substitution patterns.
 
-VIEW_NAME_SUBSTITUTION_PATTERNS : dict
+PATTERNS_VIEW_NAME_REFERENCE : dict
 """
 
 
@@ -74,7 +74,7 @@ def beautify_view_name(name):
     'Rec. 709'
     """
 
-    return beautify_name(name, VIEW_NAME_SUBSTITUTION_PATTERNS)
+    return beautify_name(name, PATTERNS_VIEW_NAME_REFERENCE)
 
 
 @required('OpenColorIO')
@@ -139,7 +139,7 @@ def node_to_builtin_transform(graph, node, direction='Forward'):
     try:
         transform_styles = []
 
-        path = (node, ACES_CONFIG_REFERENCE_COLORSPACE)
+        path = (node, COLORSPACE_SCENE_ENCODING_REFERENCE)
         path = path if direction.lower() == 'forward' else reversed(path)
         path = conversion_path(graph, *path)
 
@@ -153,9 +153,9 @@ def node_to_builtin_transform(graph, node, direction='Forward'):
         for edge in path:
             source, target = edge
             transform_styles.append(
-                f'{source.split(NODE_NAME_SEPARATOR)[-1]}'
-                f'{ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR}'
-                f'{target.split(NODE_NAME_SEPARATOR)[-1]}')
+                f'{source.split(SEPARATOR_NODE_NAME_CTL)[-1]}'
+                f'{SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE}'
+                f'{target.split(SEPARATOR_NODE_NAME_CTL)[-1]}')
 
         if len(transform_styles) == 1:
             builtin_transform = create_builtin_transform(transform_styles[0])
@@ -172,7 +172,7 @@ def node_to_builtin_transform(graph, node, direction='Forward'):
 
     except NetworkXNoPath:
         logging.debug(
-            f'No path to {ACES_CONFIG_REFERENCE_COLORSPACE} for {node}!')
+            f'No path to {COLORSPACE_SCENE_ENCODING_REFERENCE} for {node}!')
 
 
 def node_to_colorspace(graph,
@@ -267,17 +267,17 @@ def generate_config_aces(config_name=None,
     views = []
 
     scene_reference_colorspace = colorspace_factory(
-        f'CSC - {ACES_CONFIG_REFERENCE_COLORSPACE}',
+        f'CSC - {COLORSPACE_SCENE_ENCODING_REFERENCE}',
         'ACES',
         description='The "Academy Color Encoding System" reference colorspace.'
     )
 
     display_reference_colorspace = colorspace_factory(
-        f'CSC - {ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE}',
+        f'CSC - {COLORSPACE_OUTPUT_ENCODING_REFERENCE}',
         'ACES',
         description='The "Output Color Encoding Specification" colorspace.',
         from_reference=node_to_builtin_transform(
-            graph, ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE, 'Reverse'))
+            graph, COLORSPACE_OUTPUT_ENCODING_REFERENCE, 'Reverse'))
 
     raw_colorspace = colorspace_factory(
         'Utility - Raw',
@@ -294,8 +294,8 @@ def generate_config_aces(config_name=None,
     for family in ('csc', 'input_transform', 'lmt', 'output_transform'):
         family_colourspaces = []
         for node in filter_nodes(graph, [lambda x: x.family == family]):
-            if node in (ACES_CONFIG_REFERENCE_COLORSPACE,
-                        ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE):
+            if node in (COLORSPACE_SCENE_ENCODING_REFERENCE,
+                        COLORSPACE_OUTPUT_ENCODING_REFERENCE):
                 continue
 
             colorspace = node_to_colorspace(graph, node, describe)

--- a/opencolorio_config_aces/config/reference/generate/config.py
+++ b/opencolorio_config_aces/config/reference/generate/config.py
@@ -24,7 +24,8 @@ from opencolorio_config_aces.config.generation import (
 from opencolorio_config_aces.config.reference import (
     classify_aces_ctl_transforms, discover_aces_ctl_transforms,
     unclassify_ctl_transforms)
-from opencolorio_config_aces.utilities import git_describe, required
+from opencolorio_config_aces.utilities import (git_describe, multi_replace,
+                                               required)
 
 __author__ = 'OpenColorIO Contributors'
 __copyright__ = 'Copyright Contributors to the OpenColorIO Project.'
@@ -260,10 +261,7 @@ def beautify_name(name, patterns):
     'Rec. 709 (100 nits) dim'
     """
 
-    for pattern, substitution in patterns.items():
-        name = re.sub(pattern, substitution, name)
-
-    return name.strip()
+    return multi_replace(name, patterns).strip()
 
 
 def beautify_colorspace_name(name):

--- a/opencolorio_config_aces/config/reference/generate/config.py
+++ b/opencolorio_config_aces/config/reference/generate/config.py
@@ -34,17 +34,16 @@ __email__ = 'ocio-dev@lists.aswf.io'
 __status__ = 'Production'
 
 __all__ = [
-    'ACES_CONFIG_REFERENCE_MAPPING_FILE_PATH',
-    'ACES_CONFIG_REFERENCE_COLORSPACE',
-    'ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE',
-    'ACES_CONFIG_COLORSPACE_NAME_SEPARATOR',
-    'ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR',
-    'ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR',
-    'ACES_CONFIG_DISPLAY_FAMILY', 'COLORSPACE_NAME_SUBSTITUTION_PATTERNS',
-    'LOOK_NAME_SUBSTITUTION_PATTERNS',
-    'TRANSFORM_FAMILY_SUBSTITUTION_PATTERNS',
-    'VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS',
-    'DISPLAY_NAME_SUBSTITUTION_PATTERNS', 'ColorspaceDescriptionStyle',
+    'PATH_TRANSFORMS_MAPPING_FILE_REFERENCE',
+    'COLORSPACE_SCENE_ENCODING_REFERENCE',
+    'COLORSPACE_OUTPUT_ENCODING_REFERENCE', 'FAMILY_DISPLAY_REFERENCE',
+    'SEPARATOR_COLORSPACE_NAME_REFERENCE',
+    'SEPARATOR_COLORSPACE_FAMILY_REFERENCE',
+    'SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE',
+    'PATTERNS_COLORSPACE_NAME_REFERENCE', 'PATTERNS_LOOK_NAME_REFERENCE',
+    'PATTERNS_TRANSFORM_FAMILY_REFERENCE',
+    'PATTERNS_VIEW_TRANSFORM_NAME_REFERENCE',
+    'PATTERNS_DISPLAY_NAME_REFERENCE', 'ColorspaceDescriptionStyle',
     'beautify_name', 'beautify_colorspace_name', 'beautify_look_name',
     'beautify_transform_family', 'beautify_view_transform_name',
     'beautify_display_name', 'ctl_transform_to_colorspace_name',
@@ -54,7 +53,7 @@ __all__ = [
     'style_to_display_colorspace', 'generate_config_aces'
 ]
 
-ACES_CONFIG_REFERENCE_MAPPING_FILE_PATH = (
+PATH_TRANSFORMS_MAPPING_FILE_REFERENCE = (
     Path(__file__).parents[0] / 'resources' /
     'OpenColorIO-Config-ACES _Reference_ Transforms - '
     'Reference Config - Mapping.csv')
@@ -64,49 +63,49 @@ Path to the *ACES* *CTL* transforms to *OpenColorIO* colorspaces mapping file.
 CONFIG_MAPPING_FILE_PATH : unicode
 """
 
-ACES_CONFIG_REFERENCE_COLORSPACE = 'ACES2065-1'
+COLORSPACE_SCENE_ENCODING_REFERENCE = 'ACES2065-1'
 """
 *OpenColorIO* config reference colorspace.
 
-ACES_CONFIG_REFERENCE_COLORSPACE : unicode
+COLORSPACE_SCENE_ENCODING_REFERENCE : unicode
 """
 
-ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE = 'OCES'
+COLORSPACE_OUTPUT_ENCODING_REFERENCE = 'OCES'
 """
 *OpenColorIO* config output encoding colorspace.
 
-ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE : unicode
+COLORSPACE_OUTPUT_ENCODING_REFERENCE : unicode
 """
 
-ACES_CONFIG_COLORSPACE_NAME_SEPARATOR = ' - '
-"""
-*OpenColorIO* config colorspace name separator.
-
-ACES_CONFIG_COLORSPACE_NAME_SEPARATOR : unicode
-"""
-
-ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR = '/'
-"""
-*OpenColorIO* config colorspace family separator.
-
-ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR : unicode
-"""
-
-ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR = '_to_'
-"""
-*OpenColorIO* config *BuiltinTransform* name separator.
-
-ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR : unicode
-"""
-
-ACES_CONFIG_DISPLAY_FAMILY = 'Display'
+FAMILY_DISPLAY_REFERENCE = 'Display'
 """
 *OpenColorIO* config display family.
 
-ACES_CONFIG_DISPLAY_FAMILY : unicode
+FAMILY_DISPLAY_REFERENCE : unicode
 """
 
-COLORSPACE_NAME_SUBSTITUTION_PATTERNS = {
+SEPARATOR_COLORSPACE_NAME_REFERENCE = ' - '
+"""
+*OpenColorIO* config colorspace name separator.
+
+SEPARATOR_COLORSPACE_NAME_REFERENCE : unicode
+"""
+
+SEPARATOR_COLORSPACE_FAMILY_REFERENCE = '/'
+"""
+*OpenColorIO* config colorspace family separator.
+
+SEPARATOR_COLORSPACE_FAMILY_REFERENCE : unicode
+"""
+
+SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE = '_to_'
+"""
+*OpenColorIO* config *BuiltinTransform* name separator.
+
+SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE : unicode
+"""
+
+PATTERNS_COLORSPACE_NAME_REFERENCE = {
     'ACES_0_1_1': 'ACES 0.1.1',
     'ACES_0_2_2': 'ACES 0.2.2',
     'ACES_0_7_1': 'ACES 0.7.1',
@@ -128,20 +127,20 @@ Notes
 -----
 - The substitutions are evaluated in order.
 
-COLORSPACE_NAME_SUBSTITUTION_PATTERNS : dict
+PATTERNS_COLORSPACE_NAME_REFERENCE : dict
 """
 
-COLORSPACE_NAME_SUBSTITUTION_PATTERNS.update({
+PATTERNS_COLORSPACE_NAME_REFERENCE.update({
     # Input transforms also use the "family" name and thus need beautifying.
-    (f'{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}Alexa'
-     f'{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}v\\d+'
-     f'{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}.*'):
+    (f'{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}Alexa'
+     f'{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}v\\d+'
+     f'{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}.*'):
     '',
-    f'{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}':
-    ACES_CONFIG_COLORSPACE_NAME_SEPARATOR,
+    f'{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}':
+    SEPARATOR_COLORSPACE_NAME_REFERENCE,
 })
 
-LOOK_NAME_SUBSTITUTION_PATTERNS = {
+PATTERNS_LOOK_NAME_REFERENCE = {
     # TODO: Implement support for callable patterns.
     # The following ones should be a dedicated definition/callable.
     'BlueLightArtifactFix': 'Blue Light Artifact Fix',
@@ -154,11 +153,11 @@ Notes
 -----
 - The substitutions are evaluated in order.
 
-LOOK_NAME_SUBSTITUTION_PATTERNS : dict
+PATTERNS_LOOK_NAME_REFERENCE : dict
 """
 
-TRANSFORM_FAMILY_SUBSTITUTION_PATTERNS = {
-    '\\\\': ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR,
+PATTERNS_TRANSFORM_FAMILY_REFERENCE = {
+    '\\\\': SEPARATOR_COLORSPACE_FAMILY_REFERENCE,
     'vendorSupplied[/\\\\]': '',
     'arri': 'ARRI',
     'alexa': 'Alexa',
@@ -174,10 +173,10 @@ Notes
 -----
 - The substitutions are evaluated in order.
 
-TRANSFORM_FAMILY_SUBSTITUTION_PATTERNS : dict
+PATTERNS_TRANSFORM_FAMILY_REFERENCE : dict
 """
 
-VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS = {
+PATTERNS_VIEW_TRANSFORM_NAME_REFERENCE = {
     '7.2nit': '&',
     '15nit': '&',
     'lim': ' lim',
@@ -193,10 +192,10 @@ VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS = {
 """
 *OpenColorIO* view transform name substitution patterns.
 
-VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS : dict
+PATTERNS_VIEW_TRANSFORM_NAME_REFERENCE : dict
 """
 
-DISPLAY_NAME_SUBSTITUTION_PATTERNS = {
+PATTERNS_DISPLAY_NAME_REFERENCE = {
     'G2.6-': '',
     '-BFD': '',
     'REC.1886': 'Rec.1886',
@@ -218,7 +217,7 @@ Notes
 -----
 - The substitutions are evaluated in order.
 
-DISPLAY_NAME_SUBSTITUTION_PATTERNS : dict
+PATTERNS_DISPLAY_NAME_REFERENCE : dict
 """
 
 
@@ -257,7 +256,7 @@ def beautify_name(name, patterns):
     --------
     >>> beautify_name(
     ...     'Rec709_100nits_dim',
-    ...     COLORSPACE_NAME_SUBSTITUTION_PATTERNS)
+    ...     PATTERNS_COLORSPACE_NAME_REFERENCE)
     'Rec. 709 (100 nits) dim'
     """
 
@@ -288,7 +287,7 @@ def beautify_colorspace_name(name):
     'Rec. 709 (100 nits) dim'
     """
 
-    return beautify_name(name, COLORSPACE_NAME_SUBSTITUTION_PATTERNS)
+    return beautify_name(name, PATTERNS_COLORSPACE_NAME_REFERENCE)
 
 
 def beautify_look_name(name):
@@ -312,7 +311,7 @@ def beautify_look_name(name):
     'Blue Light Artifact Fix'
     """
 
-    return beautify_name(name, LOOK_NAME_SUBSTITUTION_PATTERNS)
+    return beautify_name(name, PATTERNS_LOOK_NAME_REFERENCE)
 
 
 def beautify_transform_family(name):
@@ -336,7 +335,7 @@ def beautify_transform_family(name):
     'ARRI/Alexa/v3/EI800'
     """
 
-    return beautify_name(name, TRANSFORM_FAMILY_SUBSTITUTION_PATTERNS)
+    return beautify_name(name, PATTERNS_TRANSFORM_FAMILY_REFERENCE)
 
 
 def beautify_view_transform_name(name):
@@ -361,16 +360,16 @@ def beautify_view_transform_name(name):
     'Output - SDR Cinema - ACES 1.0'
     """
 
-    basename, version = name.split(ACES_CONFIG_COLORSPACE_NAME_SEPARATOR)[
+    basename, version = name.split(SEPARATOR_COLORSPACE_NAME_REFERENCE)[
         -1].split('_')
 
     tokens = basename.split('-')
     family, genus = (['-'.join(tokens[:2]), '-'.join(tokens[2:])]
                      if len(tokens) > 2 else [basename, None])
 
-    family = beautify_name(family, VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS)
+    family = beautify_name(family, PATTERNS_VIEW_TRANSFORM_NAME_REFERENCE)
 
-    genus = (beautify_name(genus, VIEW_TRANSFORM_NAME_SUBSTITUTION_PATTERNS)
+    genus = (beautify_name(genus, PATTERNS_VIEW_TRANSFORM_NAME_REFERENCE)
              if genus is not None else genus)
 
     return (f'Output - {family} ({genus}) - ACES {version}'
@@ -400,9 +399,9 @@ def beautify_display_name(name):
     'Display - Rec. 709'
     """
 
-    basename = name.split(ACES_CONFIG_BUILTIN_TRANSFORM_NAME_SEPARATOR)[-1]
+    basename = name.split(SEPARATOR_BUILTIN_TRANSFORM_NAME_REFERENCE)[-1]
 
-    name = beautify_name(basename, DISPLAY_NAME_SUBSTITUTION_PATTERNS)
+    name = beautify_name(basename, PATTERNS_DISPLAY_NAME_REFERENCE)
 
     return f'Display - {name}'
 
@@ -424,8 +423,8 @@ def ctl_transform_to_colorspace_name(ctl_transform):
         *OpenColorIO* colorspace name.
     """
 
-    if ctl_transform.source in (ACES_CONFIG_REFERENCE_COLORSPACE,
-                                ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE):
+    if ctl_transform.source in (COLORSPACE_SCENE_ENCODING_REFERENCE,
+                                COLORSPACE_OUTPUT_ENCODING_REFERENCE):
         name = ctl_transform.target
     else:
         name = ctl_transform.source
@@ -449,8 +448,8 @@ def ctl_transform_to_look_name(ctl_transform):
         *OpenColorIO* look name.
     """
 
-    if ctl_transform.source in (ACES_CONFIG_REFERENCE_COLORSPACE,
-                                ACES_CONFIG_OUTPUT_ENCODING_COLORSPACE):
+    if ctl_transform.source in (COLORSPACE_SCENE_ENCODING_REFERENCE,
+                                COLORSPACE_OUTPUT_ENCODING_REFERENCE):
         name = ctl_transform.target
     else:
         name = ctl_transform.source
@@ -484,7 +483,7 @@ def ctl_transform_to_transform_family(ctl_transform, analytical=True):
                 and ctl_transform.namespace == 'Academy'):
             family = 'CSC'
         elif ctl_transform.family == 'input_transform':
-            family = (f'Input{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}'
+            family = (f'Input{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}'
                       f'{ctl_transform.genus}')
         elif ctl_transform.family == 'output_transform':
             family = 'Output'
@@ -496,10 +495,10 @@ def ctl_transform_to_transform_family(ctl_transform, analytical=True):
             if re.match('ACES|ADX', ctl_transform.name):
                 family = 'ACES'
             else:
-                family = (f'Input{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}'
+                family = (f'Input{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}'
                           f'{ctl_transform.genus}')
         elif ctl_transform.family == 'input_transform':
-            family = (f'Input{ACES_CONFIG_COLORSPACE_FAMILY_SEPARATOR}'
+            family = (f'Input{SEPARATOR_COLORSPACE_FAMILY_REFERENCE}'
                       f'{ctl_transform.genus}')
         elif ctl_transform.family == 'output_transform':
             family = 'Output'
@@ -639,7 +638,7 @@ def ctl_transform_to_colorspace(ctl_transform,
 
     signature = {
         'name': (f'{beautify_colorspace_name(family)}'
-                 f'{ACES_CONFIG_COLORSPACE_NAME_SEPARATOR}'
+                 f'{SEPARATOR_COLORSPACE_NAME_REFERENCE}'
                  f'{name}'),
         'family':
         family,
@@ -699,7 +698,7 @@ def ctl_transform_to_look(ctl_transform,
 
     signature = {
         'name': (f'{beautify_colorspace_name(family)}'
-                 f'{ACES_CONFIG_COLORSPACE_NAME_SEPARATOR}'
+                 f'{SEPARATOR_COLORSPACE_NAME_REFERENCE}'
                  f'{name}'),
         'description':
         description,
@@ -851,7 +850,7 @@ def style_to_display_colorspace(
 
     import PyOpenColorIO as ocio
 
-    kwargs.setdefault('family', ACES_CONFIG_DISPLAY_FAMILY)
+    kwargs.setdefault('family', FAMILY_DISPLAY_REFERENCE)
 
     name = beautify_display_name(style)
     builtin_transform = ocio.BuiltinTransform(style)
@@ -869,7 +868,7 @@ def style_to_display_colorspace(
 
     signature = {
         'name': name,
-        'family': ACES_CONFIG_DISPLAY_FAMILY,
+        'family': FAMILY_DISPLAY_REFERENCE,
         'description': description,
         'from_reference': builtin_transform,
         'reference_space': 'REFERENCE_SPACE_DISPLAY',
@@ -894,7 +893,7 @@ def generate_config_aces(
         config_name=None,
         validate=True,
         describe=ColorspaceDescriptionStyle.SHORT_UNION,
-        config_mapping_file_path=ACES_CONFIG_REFERENCE_MAPPING_FILE_PATH,
+        config_mapping_file_path=PATH_TRANSFORMS_MAPPING_FILE_REFERENCE,
         analytical=True,
         additional_data=False):
     """
@@ -1013,7 +1012,7 @@ def generate_config_aces(
 
     scene_reference_colorspace = {
         'name':
-        f'{aces_family_prefix} - {ACES_CONFIG_REFERENCE_COLORSPACE}',
+        f'{aces_family_prefix} - {COLORSPACE_SCENE_ENCODING_REFERENCE}',
         'family':
         'ACES',
         'description':

--- a/opencolorio_config_aces/utilities/__init__.py
+++ b/opencolorio_config_aces/utilities/__init__.py
@@ -1,17 +1,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-from .common import (DocstringDict, first_item, common_ancestor,
-                     paths_common_ancestor, vivification, vivified_to_dict,
-                     message_box, is_colour_installed, is_jsonpickle_installed,
-                     is_networkx_installed, is_opencolorio_installed,
-                     REQUIREMENTS_TO_CALLABLE, required, is_string,
-                     is_iterable, git_describe, matrix_3x3_to_4x4)
+from .common import (
+    DocstringDict, first_item, common_ancestor, paths_common_ancestor,
+    vivification, vivified_to_dict, message_box, is_colour_installed,
+    is_jsonpickle_installed, is_networkx_installed, is_opencolorio_installed,
+    REQUIREMENTS_TO_CALLABLE, required, is_string, is_iterable, git_describe,
+    matrix_3x3_to_4x4, multi_replace)
 
 __all__ = [
     'DocstringDict', 'first_item', 'common_ancestor', 'paths_common_ancestor',
     'vivification', 'vivified_to_dict', 'message_box', 'is_colour_installed',
     'is_jsonpickle_installed', 'is_networkx_installed',
     'is_opencolorio_installed', 'REQUIREMENTS_TO_CALLABLE', 'required',
-    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4'
+    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4',
+    'multi_replace'
 ]

--- a/opencolorio_config_aces/utilities/__init__.py
+++ b/opencolorio_config_aces/utilities/__init__.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-from .common import (
-    DocstringDict, first_item, common_ancestor, paths_common_ancestor,
-    vivification, vivified_to_dict, message_box, is_colour_installed,
-    is_jsonpickle_installed, is_networkx_installed, is_opencolorio_installed,
-    REQUIREMENTS_TO_CALLABLE, required, is_string, is_iterable, git_describe)
+from .common import (DocstringDict, first_item, common_ancestor,
+                     paths_common_ancestor, vivification, vivified_to_dict,
+                     message_box, is_colour_installed, is_jsonpickle_installed,
+                     is_networkx_installed, is_opencolorio_installed,
+                     REQUIREMENTS_TO_CALLABLE, required, is_string,
+                     is_iterable, git_describe, matrix_3x3_to_4x4)
 
 __all__ = [
     'DocstringDict', 'first_item', 'common_ancestor', 'paths_common_ancestor',
     'vivification', 'vivified_to_dict', 'message_box', 'is_colour_installed',
     'is_jsonpickle_installed', 'is_networkx_installed',
     'is_opencolorio_installed', 'REQUIREMENTS_TO_CALLABLE', 'required',
-    'is_string', 'is_iterable', 'git_describe'
+    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4'
 ]

--- a/opencolorio_config_aces/utilities/common.py
+++ b/opencolorio_config_aces/utilities/common.py
@@ -9,6 +9,7 @@ Defines common utilities objects that don't fall in any specific category.
 
 import functools
 import os
+import re
 import subprocess
 from collections import defaultdict
 from itertools import chain
@@ -26,7 +27,8 @@ __all__ = [
     'vivification', 'vivified_to_dict', 'message_box', 'is_colour_installed',
     'is_jsonpickle_installed', 'is_networkx_installed',
     'is_opencolorio_installed', 'REQUIREMENTS_TO_CALLABLE', 'required',
-    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4'
+    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4',
+    'multi_replace'
 ]
 
 
@@ -531,3 +533,35 @@ def matrix_3x3_to_4x4(M):
     M_I[:3, :3] = M
 
     return np.ravel(M_I).tolist()
+
+
+def multi_replace(name, patterns):
+    """
+    Updates given name by applying in succession the given patterns and
+    substitutions.
+
+    Parameters
+    ----------
+    name : unicode
+        Name to update.
+    patterns : dict
+        Dictionary of regular expression patterns and substitution to apply
+        onto the name.
+
+    Returns
+    -------
+    unicode
+        Updated name.
+
+    Examples
+    --------
+    >>> multi_replace(
+    ...     'Canon Luke Skywalker was weak and powerless.',
+    ...     {'Canon': 'Legends', 'weak': 'strong', '\\w+less': 'powerful'})
+    'Legends Luke Skywalker was strong and powerful.'
+    """
+
+    for pattern, substitution in patterns.items():
+        name = re.sub(pattern, substitution, name)
+
+    return name

--- a/opencolorio_config_aces/utilities/common.py
+++ b/opencolorio_config_aces/utilities/common.py
@@ -26,7 +26,7 @@ __all__ = [
     'vivification', 'vivified_to_dict', 'message_box', 'is_colour_installed',
     'is_jsonpickle_installed', 'is_networkx_installed',
     'is_opencolorio_installed', 'REQUIREMENTS_TO_CALLABLE', 'required',
-    'is_string', 'is_iterable', 'git_describe'
+    'is_string', 'is_iterable', 'git_describe', 'matrix_3x3_to_4x4'
 ]
 
 
@@ -505,3 +505,29 @@ def git_describe():
         version = opencolorio_config_aces.__version__
 
     return version
+
+
+# TODO: Numpy currently comes via "Colour", we might want that to be an
+# explicit dependency in the future.
+@required('Colour')
+def matrix_3x3_to_4x4(M):
+    """
+    Converts given 3x3 matrix :math:`M` to a raveled 4x4 matrix.
+
+    Parameters
+    ----------
+    M : array_like
+        3x3 matrix :math:`M` to convert.
+
+    Returns
+    -------
+    list
+        Raveled 4x4 matrix.
+    """
+
+    import numpy as np
+
+    M_I = np.identity(4)
+    M_I[:3, :3] = M
+
+    return np.ravel(M_I).tolist()


### PR DESCRIPTION
Hi,

A PR implementing minor improvements:

- Updated the naming of various private attributes for better introspection and consistency:
![image](https://user-images.githubusercontent.com/99779/131654433-750bf5ef-f6ac-40e6-ad90-a3c205e1d97c.png)
We did that in Colour last year and it was a great move: https://github.com/colour-science/colour/pull/618
- Move `opencolorio_config_aces.clf.matrix_3x3_to_4x4` definition to `opencolorio_config_aces.utilities` sub-package.
- Add `opencolorio_config_aces.utilities.multi_replace` generic definition to be used by `opencolorio_config_aces.config.reference.generate.config.beautify_name` definition.