### PR TITLE
PR: Use config basename as config inner name.

### DIFF
--- a/opencolorio_config_aces/config/cg/generate/config.py
+++ b/opencolorio_config_aces/config/cg/generate/config.py
@@ -12,6 +12,7 @@ Graphics (CG) *OpenColorIO* config:
 
 import csv
 import logging
+import re
 
 import PyOpenColorIO as ocio
 from collections import defaultdict
@@ -313,10 +314,17 @@ def config_name_cg(config_mapping_file_path=PATH_TRANSFORMS_MAPPING_FILE_CG):
     ).format(**dependency_versions(config_mapping_file_path))
 
 
-def config_description_cg():
+def config_description_cg(
+    config_mapping_file_path=PATH_TRANSFORMS_MAPPING_FILE_CG,
+):
     """
     Generate the ACES* Computer Graphics (CG) *OpenColorIO* config
     description.
+
+    Parameters
+    ----------
+    config_mapping_file_path : str, optional
+        Path to the *CSV* mapping file.
 
     Returns
     -------
@@ -324,11 +332,8 @@ def config_description_cg():
         ACES* Computer Graphics (CG) *OpenColorIO* config description.
     """
 
-    header = (
-        f'The "Academy Color Encoding System" (ACES {version_aces_dev()}) '
-        f'"CG Config"'
-    )
-    underline = "-" * len(header)
+    name = config_name_cg(config_mapping_file_path)
+    underline = "-" * len(name)
     description = (
         'This minimalistic "OpenColorIO" config is geared toward computer '
         "graphics artists requiring a lean config that does not include "
@@ -339,7 +344,7 @@ def config_description_cg():
         f'on the {datetime.now().strftime("%Y/%m/%d at %H:%M")}.'
     )
 
-    return "\n".join([header, underline, "", description, "", timestamp])
+    return "\n".join([name, underline, "", description, "", timestamp])
 
 
 def generate_config_cg(
@@ -412,8 +417,10 @@ def generate_config_cg(
                 transform_data
             )
 
-    data.name = config_name_cg(config_mapping_file_path)
-    data.description = config_description_cg()
+    data.name = re.sub(
+        r"\.ocio$", "", config_basename_cg(config_mapping_file_path)
+    )
+    data.description = config_description_cg(config_mapping_file_path)
 
     def multi_filters(array, filterers):
         """Apply given filterers on given array."""

--- a/opencolorio_config_aces/config/reference/generate/config.py
+++ b/opencolorio_config_aces/config/reference/generate/config.py
@@ -1111,10 +1111,17 @@ def config_name_aces(
     ).format(**dependency_versions(config_mapping_file_path))
 
 
-def config_description_aces():
+def config_description_aces(
+    config_mapping_file_path=PATH_TRANSFORMS_MAPPING_FILE_REFERENCE,
+):
     """
     Generate the *aces-dev* reference implementation *OpenColorIO* Config
     description.
+
+    Parameters
+    ----------
+    config_mapping_file_path : str, optional
+        Path to the *CSV* mapping file.
 
     Returns
     -------
@@ -1122,11 +1129,8 @@ def config_description_aces():
         *aces-dev* reference implementation *OpenColorIO* Config description.
     """
 
-    header = (
-        f'The "Academy Color Encoding System" (ACES {version_aces_dev()}) '
-        f'"Reference Config"'
-    )
-    underline = "-" * len(header)
+    name = config_name_aces(config_mapping_file_path)
+    underline = "-" * len(name)
     description = (
         'This "OpenColorIO" config is a strict and quasi-analytical '
         'implementation of "aces-dev" and is designed as a reference to '
@@ -1139,7 +1143,7 @@ def config_description_aces():
         f'on the {datetime.now().strftime("%Y/%m/%d at %H:%M")}.'
     )
 
-    return "\n".join([header, underline, "", description, "", timestamp])
+    return "\n".join([name, underline, "", description, "", timestamp])
 
 
 def generate_config_aces(
@@ -1387,8 +1391,10 @@ def generate_config_aces(
         )
 
     data = ConfigData(
-        name=config_name_aces(config_mapping_file_path),
-        description=config_description_aces(),
+        name=re.sub(
+            r"\.ocio$", "", config_basename_aces(config_mapping_file_path)
+        ),
+        description=config_description_aces(config_mapping_file_path),
         roles={
             ocio.ROLE_COLOR_TIMING: f"{aces_family_prefix} - ACEScct",
             ocio.ROLE_COMPOSITING_LOG: f"{aces_family_prefix} - ACEScct",


### PR DESCRIPTION
This PR ensures that the config base name is used as the config inner name as described in #52. Reference and CG configs headers are now as follows, respectively:

```yaml
ocio_profile_version: 2.1

environment:
  {}
search_path: ""
strictparsing: true
luma: [0.2126, 0.7152, 0.0722]
name: cg-config-v0.1.0_aces-v1.3_ocio-v2.2.0dev
description: |
  Academy Color Encoding System - CG Config [COLORSPACES v0.1.0] [ACES v1.3] [OCIO v2.2.0dev]
  -------------------------------------------------------------------------------------------

  This minimalistic "OpenColorIO" config is geared toward computer graphics artists requiring a lean config that does not include camera colorspaces and the less common displays and looks.

  Generated with "OpenColorIO-Config-ACES" v0.1.1-15-geb59486 on the 2022/06/05 at 11:20.
```

```yaml
ocio_profile_version: 2.1

environment:
  {}
search_path: ""
strictparsing: true
luma: [0.2126, 0.7152, 0.0722]
name: reference-config-v0.1.0_aces-v1.3_ocio-v2.2.0dev
description: |
  Academy Color Encoding System - Reference Config [COLORSPACES v0.1.0] [ACES v1.3] [OCIO v2.2.0dev]
  --------------------------------------------------------------------------------------------------

  This "OpenColorIO" config is a strict and quasi-analytical implementation of "aces-dev" and is designed as a reference to validate the implementation of the "ampas/aces-dev" "GitHub" "CTL" transforms in OpenColorIO. It is not a replacement for the previous "ACES" configs nor the "ACES Studio Config".

  Generated with "OpenColorIO-Config-ACES" v0.1.1-15-geb59486 on the 2022/06/05 at 11:20.
```
