### PR TITLE
PR: Use "pytest" instead of "py.test" in CI.

### DIFF
--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
       shell: bash
     - name: Test with Pytest
       run: |
-        poetry run python -W ignore -m py.test --disable-warnings --doctest-modules --ignore=$CI_PACKAGE/config/reference/aces-dev --cov=$CI_PACKAGE $CI_PACKAGE
+        poetry run python -W ignore -m pytest --disable-warnings --doctest-modules --ignore=$CI_PACKAGE/config/reference/aces-dev --cov=$CI_PACKAGE $CI_PACKAGE
       shell: bash
 #    - name: Upload Coverage to coveralls.io
 #      run: |


### PR DESCRIPTION
Title says it all! It should fix the latest broken CI.